### PR TITLE
0.8.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<38]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "atom" %}
-{% set version = "0.6.0" %}
-{% set sha256 = "df65a654744ccdc4843ce09c38612fd8f702c84be501b1d955c3ac0b9ad28dc5" %}
+{% set version = "0.8.2" %}
+{% set sha256 = "3155b7a0a286cb5c2bff2929fc2341d071dc9169b0d0ff1f15450ddd57d24c57" %}
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -20,10 +20,10 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools_scm
     - cppy
   run:
     - python
-    - future
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,12 +39,13 @@ about:
   home: https://github.com/nucleic/atom
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
   summary: Memory efficient Python objects
   description: |
     Atom is a framework for creating memory efficient Python objects
     with enhanced features such as dynamic initialization, validation, and
     change notification for object attributes.
-  doc_url: http://flight-manual.atom.io/
+  doc_url: https://flight-manual.atom.io/
   dev_url: https://github.com/nucleic/atom
 
 extra:
@@ -55,3 +56,6 @@ extra:
     - MatthieuDartiailh
     - sccolbert
     - tacaswell
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - setuptools
     - setuptools_scm
+    - wheel
     - cppy
   run:
     - python
@@ -31,6 +32,8 @@ test:
     - atom.catom
     - atom.datastructures
     - atom.datastructures.sortedmap
+  commands:
+    - pip check
 
 about:
   home: https://github.com/nucleic/atom

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,9 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
+    - python
   imports:
     - atom
     - atom.catom


### PR DESCRIPTION
# Atom 0.8.2

upstream: https://github.com/nucleic/atom/tree/0.8.2
jira: https://anaconda.atlassian.net/browse/PKG-890
license: https://github.com/nucleic/atom/blob/0.8.2/LICENSE
`setup.py`:https://github.com/nucleic/atom/blob/0.8.2/setup.py
`pyproject.toml`: https://github.com/nucleic/atom/blob/0.8.2/pyproject.toml#L39

## Changes
- Update SHA and version
- Remove future as a dependency. It was dropped in 0.4.2
- Add `setuptools_scm` from pyproject
- `pip check` test

## Notes
- This adds python 3.11 support